### PR TITLE
Allow configure to run on netbsd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,11 +18,11 @@ AS_CASE([$host_os],
                    [PLATFORM="nix"])
 
 PKG_CHECK_MODULES([expat], [expat >= 2.0.0],
-                  [PC_REQUIRES+=(expat)],
+                  [PC_REQUIRES="expat ${PC_REQUIRES}"],
                   [AC_CHECK_HEADER([expat.h],
                                    [
                                     expat_LIBS="-lexpat"
-                                    PC_LIBS+=($expat_LIBS)
+                                    PC_LIBS="${expat_LIBS} ${PC_LIBS}"
                                    ],
                                    [AC_MSG_ERROR([expat not found; expat required.])]
                                   )


### PR DESCRIPTION
NetBSD's shell (/bin/sh) doesn't support '+='. Removing '+=' allows
configure to run and the library to compile.

This matches configure.ac in boothj5/profanity which also doesn't
use '+='.