### PR TITLE
Haiku port

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,8 @@ SSL_LIBS = @openssl_LIBS@
 
 RESOLV_LIBS = @RESOLV_LIBS@
 
-MESODE_FLAGS = -I$(top_srcdir) -Wall -Wextra -Wno-unused-parameter
+WARNING_FLAGS = @WARNING_FLAGS@
+MESODE_FLAGS = -I$(top_srcdir) $(WARNING_FLAGS)
 MESODE_LIBS = libmesode.la
 
 ## Main build targets

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,12 @@ AS_CASE([$host_os],
     [*haiku*],     [PLATFORM="haiku"],
                    [PLATFORM="nix"])
 
+WARNING_FLAGS="-Wall"
+
+AS_CASE([$PLATFORM],
+    [haiku],   [],
+               [WARNING_FLAGS="$WARNING_FLAGS -Wextra -Wno-unused-parameter"])
+
 PKG_CHECK_MODULES([expat], [expat >= 2.0.0],
                   [PC_REQUIRES="expat ${PC_REQUIRES}"],
                   [AC_CHECK_HEADER([expat.h],
@@ -93,5 +99,6 @@ AC_SUBST([PC_LIBS], [${PC_LIBS}])
 AC_SUBST(PARSER_CFLAGS)
 AC_SUBST(PARSER_LIBS)
 AC_SUBST(RESOLV_LIBS)
+AC_SUBST(WARNING_FLAGS)
 AC_CONFIG_FILES([Makefile libmesode.pc])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ AS_CASE([$host_os],
     [*nto*|*qnx*], [PLATFORM="qnx"],
     [*solaris*],   [PLATFORM="solaris"],
     [*android*],   [PLATFORM="android"],
+    [*haiku*],     [PLATFORM="haiku"],
                    [PLATFORM="nix"])
 
 PKG_CHECK_MODULES([expat], [expat >= 2.0.0],
@@ -47,13 +48,14 @@ if test "x$enable_tls" != xno; then
         )])
 fi
 
-AC_SEARCH_LIBS([socket], [socket])
+AC_SEARCH_LIBS([socket], [network socket])
 
 AS_CASE([$PLATFORM],
     [bsd],     [RESOLV_LIBS=""],
     [qnx],     [RESOLV_LIBS="-lsocket"],
     [solaris], [RESOLV_LIBS="-lresolv -lsocket -lnsl"],
     [android], [RESOLV_LIBS=""],
+    [haiku],   [RESOLV_LIBS="-lnetwork"],
                [RESOLV_LIBS="-lresolv"])
 
 LIBS_TMP="${LIBS}"

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -50,7 +50,7 @@
 #include "util.h"
 
 /* Workaround for visual studio without va_copy support. */
-#if defined(_MSC_VER) && _MSC_VER < 1800
+#if defined(_MSC_VER) && _MSC_VER < 1800 || defined(__HAIKU__)
 #define va_copy(d,s) ((d) = (s))
 #endif
 


### PR DESCRIPTION
This fixes the build for Haiku:
- va_copy isn't yet available,
- we prefer to have C89 which allows to build for the primary arch, even though we have latest GCC as secondary arch,
- we have all of socket and resolver stuff in libnetwork and we want to avoid libsocket which is a compatibility lib for one of the BeOS network stacks,
- GCC 2.95 doesn't know some warning flags.