### PR TITLE
Enable distro-defined OpenSSL trust store

### DIFF
--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -320,6 +320,7 @@ tls_t *tls_new(xmpp_conn_t *conn)
         SSL_CTX_set_client_cert_cb(tls->ssl_ctx, NULL);
         SSL_CTX_set_mode(tls->ssl_ctx, SSL_MODE_ENABLE_PARTIAL_WRITE);
         SSL_CTX_set_verify(tls->ssl_ctx, SSL_VERIFY_PEER, verify_callback);
+        SSL_CTX_set_default_verify_paths(tls->ssl_ctx);
         if (conn->tls_cert_path) {
             SSL_CTX_load_verify_locations(tls->ssl_ctx, NULL, conn->tls_cert_path);
         }


### PR DESCRIPTION
Without `SSL_CTX_set_default_verify_paths()`, `SSL_CTX_load_verify_locations()` has to be hand-fed the right paths for the current OS. With the current library API it *only* supports CApaths and cannot support CAfiles, so even though profanity feeds it the usual default path this makes it incompatible with OpenBSD, and probably others, that only ship a CAfile.

For the difference between CApaths and CAfiles, read https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_load_verify_locations.html and/or https://man.openbsd.org/SSL_CTX_set_default_verify_paths.

Fixes https://github.com/profanity-im/profanity/issues/1234