### PR TITLE
Set the SNI

### DIFF
--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -373,6 +373,11 @@ tls_t *tls_new(xmpp_conn_t *conn)
         if (tls->ssl == NULL)
             goto err_free_ctx;
 
+	#ifdef OPENSSL_VERSION_NUMBER >= 0x0908060L && !defined(OPENSSL_NO_TLSEXT)
+		/* Enable SNI */
+		SSL_set_tlsext_host_name(tls->ssl, conn->domain);
+	#endif
+
         /* Trust server's certificate when user sets the flag explicitly. */
         mode = conn->tls_trust ? SSL_VERIFY_NONE : SSL_VERIFY_PEER;
         SSL_set_verify(tls->ssl, mode, 0);


### PR DESCRIPTION
I have an XMPP server behind traefik which routes connections based on the SNI. Profanity - or more precise libmesode - does not set the SNI, which prevents profanity from connecting to my server.

This PR just ports the libstrophe commit f0436490b0d6272a122648ebd50156145718fb97, which in my test allowed profanity to connect to my server.